### PR TITLE
No space in parens for [], {}, ()

### DIFF
--- a/.eslintrc-core.json
+++ b/.eslintrc-core.json
@@ -30,7 +30,7 @@
     "semi-spacing": [2, {"before": false, "after": true}],
     "space-before-blocks": [2],
     "space-before-function-paren": [2, "never"],
-    "space-in-parens": [2, "always"],
+    "space-in-parens": [2, "always", { "exceptions": ["{}", "[]", "()", "empty"] }],
     "space-infix-ops": [2],
     "space-unary-ops": [2, { "words": true, "nonwords": false }],
     "vars-on-top": [2]

--- a/test/1.spec.js
+++ b/test/1.spec.js
@@ -8,16 +8,16 @@ describe( '1. Whitespace', function() {
 
     expect( src ).to.not.have.eslintErrors;
 
-  } );
+  });
 
 
   it( 'should fail when 2 spaces are not used for indentation', function() {
 
     var src = 'var test;\nif ( true ) {\n\ttest = \'fail\';\n}\n';
 
-    expect( src ).to.have.eslintErrors( [ 'indent' ] );
+    expect( src ).to.have.eslintErrors([ 'indent' ]);
 
-  } );
+  });
 
 
   it( 'should fail when tabs are mixed with spaces for indent', function() {
@@ -33,24 +33,24 @@ describe( '1. Whitespace', function() {
 
     expect( src ).to.have.eslintErrors( [ 'no-mixed-spaces-and-tabs' ] );
 
-  } );
+  });
 
   it( 'should fail when no line at end of file', function() {
     var src = 'var test = 1;';
 
-    expect( src ).to.have.eslintErrors( [ 'eol-last' ] );
-  } );
+    expect( src ).to.have.eslintErrors([ 'eol-last' ]);
+  });
 
   it( 'should fail when trailing spaces at end of line', function() {
     var src = 'var test = 1;  \n';
 
-    expect( src ).to.have.eslintErrors( [ 'no-trailing-spaces' ] );
-  } );
+    expect( src ).to.have.eslintErrors([ 'no-trailing-spaces' ]);
+  });
 
   it( 'should fail when mixed linebreak', function() {
     var src = 'var test = 1;\r\n';
 
-    expect( src ).to.have.eslintErrors( [ 'linebreak-style' ] );
-  } );
+    expect( src ).to.have.eslintErrors([ 'linebreak-style' ]);
+  });
 
-} );
+});

--- a/test/1.spec.js
+++ b/test/1.spec.js
@@ -31,7 +31,7 @@ describe( '1. Whitespace', function() {
       '  }\n' +
       '}\n';
 
-    expect( src ).to.have.eslintErrors( [ 'no-mixed-spaces-and-tabs' ] );
+    expect( src ).to.have.eslintErrors([ 'no-mixed-spaces-and-tabs' ]);
 
   });
 

--- a/test/2.spec.js
+++ b/test/2.spec.js
@@ -6,75 +6,75 @@ describe( '2. Beautiful Syntax', function() {
 
     it( 'should fail when block does not start on new line', function() {
       var src = 'while ( true ) { i++; }\n';
-      expect( src ).to.have.eslintErrors( [ 'brace-style', 'brace-style' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'brace-style', 'brace-style' ]);
+    });
 
     it( 'should fail on control statement without braces', function() {
       var src = 'while ( true ) i++;\n';
-      expect( src ).to.have.eslintErrors( [ 'curly' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'curly' ]);
+    });
 
     it( 'should fail when cramped syntax around keywords', function() {
       var src = 'while( true ) {\n  i++;\n}\n';
-      expect( src ).to.have.eslintErrors( [ 'keyword-spacing' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'keyword-spacing' ]);
+    });
 
     it( 'should fail when no space before block', function() {
       var src = 'while ( true ){\n  i++;\n}\n';
-      expect( src ).to.have.eslintErrors( [ 'space-before-blocks' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'space-before-blocks' ]);
+    });
 
     it( 'should fail when no spacing inside block', function() {
       var src = 'while ( true ) {i++;\n}\n';
-      expect( src ).to.have.eslintErrors( [ 'block-spacing', 'brace-style' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'block-spacing', 'brace-style' ]);
+    });
 
     it( 'should fail when cramped syntax inside parentheses', function() {
       var src = 'var i;\nfor (i = 0; i < 100; i++) {\n  someIterativeFn();\n}\n';
-      expect( src ).to.have.eslintErrors( [ 'space-in-parens', 'space-in-parens' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'space-in-parens', 'space-in-parens' ]);
+    });
 
     it( 'should fail when no spacing inside array literal', function() {
       var src = 'var a = [\'foo\', \'bar\'];\n';
-      expect( src ).to.have.eslintErrors( [ 'array-bracket-spacing', 'array-bracket-spacing' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'array-bracket-spacing', 'array-bracket-spacing' ]);
+    });
 
     it( 'should fail when no spaces around arrow for arrow function', function() {
       var src = 'const a = b=>b * 2;\n';
-      expect( src ).to.have.eslintErrors( [ 'arrow-spacing', 'arrow-spacing' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'arrow-spacing', 'arrow-spacing' ]);
+    });
 
     it( 'should fail when no spacing in computed properties', function() {
       var src = 'global[\'foo\' ]\n';
-      expect( src ).to.have.eslintErrors( [ 'computed-property-spacing' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'computed-property-spacing' ]);
+    });
 
     it( 'should fail when no spacing after a comma', function() {
       var src = 'var a = [ \'foo\',\'bar\' ];\n';
-      expect( src ).to.have.eslintErrors( [ 'comma-spacing' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'comma-spacing' ]);
+    });
 
     it( 'should fail when spacing before object key', function() {
       var src = 'var foo = { bar : 1 };\n';
-      expect( src ).to.have.eslintErrors( [ 'key-spacing' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'key-spacing' ]);
+    });
 
     it( 'should fail when no spacing inside object braces', function() {
       var src = 'var foo = {bar: 1};\n';
-      expect( src ).to.have.eslintErrors( [ 'object-curly-spacing', 'object-curly-spacing' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'object-curly-spacing', 'object-curly-spacing' ]);
+    });
 
     it( 'should fail when spaces in function calls', function() {
       var src = 'foo ( 1 );\n';
-      expect( src ).to.have.eslintErrors( [ 'no-spaced-func' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'no-spaced-func' ]);
+    });
 
     it( 'should fail when space before function parentheses', function() {
       var src = 'function foo ( arg ) {\n}\n';
-      expect( src ).to.have.eslintErrors( [ 'space-before-function-paren' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'space-before-function-paren' ]);
+    });
 
-  } );
+  });
 
   describe( 'B. Assignments, Declarations, Functions ( Named, Expression, Constructor )', function() {
 
@@ -87,59 +87,69 @@ describe( '2. Beautiful Syntax', function() {
       '  var first;\n' +
       '}\n';
 
-      expect( src ).to.have.eslintErrors( [ 'vars-on-top' ] );
+      expect( src ).to.have.eslintErrors([ 'vars-on-top' ]);
 
-    } );
+    });
 
     it( 'should fail when more than 1 var per scope', function() {
 
       var src = 'var first;\nvar second = \'\';\n';
-      expect( src ).to.have.eslintErrors( [ 'one-var' ] );
+      expect( src ).to.have.eslintErrors([ 'one-var' ]);
 
-    } );
+    });
 
     it( 'should fail when multiple variables on same line', function() {
       var src = 'var first = 1, second = 2;\n';
-      expect( src ).to.have.eslintErrors( [ 'one-var-declaration-per-line' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'one-var-declaration-per-line' ]);
+    });
 
     it( 'should fail when no spacing around operators', function() {
       var src = 'var foo = 1+1;\n';
-      expect( src ).to.have.eslintErrors( [ 'space-infix-ops' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'space-infix-ops' ]);
+    });
 
     it( 'should fail when no spacing around return statement', function() {
       var src = 'function foo() {\n  return-1;\n}\n';
-      expect( src ).to.have.eslintErrors( [ 'keyword-spacing' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'keyword-spacing' ]);
+    });
 
     it( 'should fail when no space after unary word operator', function() {
       var src = 'typeof!foo;\n';
-      expect( src ).to.have.eslintErrors( [ 'space-unary-ops' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'space-unary-ops' ]);
+    });
 
     it( 'should fail when space next to unary non-word operator', function() {
       var src = 'var foo = foo ++;\n';
-      expect( src ).to.have.eslintErrors( [ 'space-unary-ops' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'space-unary-ops' ]);
+    });
 
     it( 'should fail when excess spacing in statements', function() {
       var src = 'var foo  = 1;\n';
-      expect( src ).to.have.eslintErrors( [ 'no-multi-spaces' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'no-multi-spaces' ]);
+    });
 
     it( 'should fail on multi-line member expression when "dot" is not on new line', function() {
       var src = 'var foo = bar.\nmap( function mapBar() { } );\n';
-      expect( src ).to.have.eslintErrors( [ 'dot-location' ] );
-    } );
+      expect( src ).to.have.eslintErrors([ 'dot-location' ]);
+    });
 
-  } );
+  });
+
+  describe( 'C. Exceptions', function() {
+    it( 'function callbacks', function() {
+      var src =
+        'foo( function cb() {\n' +
+        '  // thing\n' +
+        '})\n';
+      expect( src ).to.have.eslintErrors([ 'dot-location' ]);
+    });
+  });
 
   describe( 'E. Quotes', function() {
     it( 'should fail when not using single quotes', function() {
       var src = 'var first = "hi";\n';
-      expect( src ).to.have.eslintErrors( [ 'quotes' ] );
-    } );
-  } );
+      expect( src ).to.have.eslintErrors([ 'quotes' ]);
+    });
+  });
 
-} );
+});

--- a/test/2.spec.js
+++ b/test/2.spec.js
@@ -136,11 +136,26 @@ describe( '2. Beautiful Syntax', function() {
   });
 
   describe( 'C. Exceptions', function() {
-    it( 'function callbacks', function() {
+    // FIXME still cannot remote space before function keyword
+    it( 'should not have spaces around function callbacks', function() {
       var src =
         'foo( function cb() {\n' +
         '  // thing\n' +
         '})\n';
+      expect( src ).to.not.have.eslintErrors;
+    });
+
+    it( 'should not have spaces around arrow function callbacks', function() {
+      var src =
+        'foo(() => {\n' +
+        '  // thing\n' +
+        '});\n';
+      expect( src ).to.not.have.eslintErrors;
+    });
+
+    it( 'should not have spaces between array definitions', function() {
+      var src =
+        'foo([ \'alpha\', \'beta\' ]);\n';
       expect( src ).to.not.have.eslintErrors;
     });
   });

--- a/test/2.spec.js
+++ b/test/2.spec.js
@@ -129,7 +129,7 @@ describe( '2. Beautiful Syntax', function() {
     });
 
     it( 'should fail on multi-line member expression when "dot" is not on new line', function() {
-      var src = 'var foo = bar.\nmap( function mapBar() { } );\n';
+      var src = 'var foo = bar.\nmap( function mapBar() { });\n';
       expect( src ).to.have.eslintErrors([ 'dot-location' ]);
     });
 
@@ -141,7 +141,7 @@ describe( '2. Beautiful Syntax', function() {
         'foo( function cb() {\n' +
         '  // thing\n' +
         '})\n';
-      expect( src ).to.have.eslintErrors([ 'dot-location' ]);
+      expect( src ).to.not.have.eslintErrors;
     });
   });
 

--- a/test/3.spec.js
+++ b/test/3.spec.js
@@ -7,13 +7,13 @@ describe( '3. Type Checking', function() {
     it( 'should not fail when comparing against null', function() {
       var src = 'variable == null;\n';
       expect( src ).to.not.have.eslintErrors;
-    } );
+    });
 
     it( 'should not fail when comparing against null (strong type equal)', function() {
       var src = 'variable === null;\n';
       expect( src ).to.not.have.eslintErrors;
-    } );
+    });
 
-  } );
+  });
 
-} );
+});

--- a/test/9.spec.js
+++ b/test/9.spec.js
@@ -4,6 +4,6 @@ describe( '10. Comments', function() {
   it( 'should fail when using end of line comment', function() {
     var src = 'var foo = 1; // bar!\n';
 
-    expect( src ).to.have.eslintErrors( [ 'no-inline-comments' ] );
-  } );
-} );
+    expect( src ).to.have.eslintErrors([ 'no-inline-comments' ]);
+  });
+});

--- a/test/appendix.spec.js
+++ b/test/appendix.spec.js
@@ -6,7 +6,7 @@ describe( 'Appendix', function() {
       var src = 'var first = 1\n' +
       '  , second = 2;\n';
 
-      expect( src ).to.have.eslintErrors( [ 'comma-style' ] );
-    } );
-  } );
-} );
+      expect( src ).to.have.eslintErrors([ 'comma-style' ]);
+    });
+  });
+});

--- a/test/fixtures.spec.js
+++ b/test/fixtures.spec.js
@@ -3,11 +3,11 @@ var eslint = require( './support/eslint-adapter' );
 describe( 'fixtures', function testFixtures() {
 
   it( 'should not have eslint errors on idomatic-sample.js', function testIdomaticSample() {
-    var report = eslint.executeOnFiles( [ './test/fixtures/idiomatic-sample.js' ] ),
+    var report = eslint.executeOnFiles([ './test/fixtures/idiomatic-sample.js' ]),
       messages = eslint.formatReportResults( report.results );
 
     expect( report.results[ 0 ].errorCount, messages ).to.equal( 0 );
     expect( report.results[ 0 ].warningCount, messages ).to.equal( 0 );
-  } );
+  });
 
-} );
+});

--- a/test/fixtures/idiomatic-sample.js
+++ b/test/fixtures/idiomatic-sample.js
@@ -72,5 +72,5 @@ function style2x() {
   return foo
     .map( function fooMap( f ) {
       return f + ' bar';
-    } );
+    });
 }

--- a/test/support/eslint-adapter.js
+++ b/test/support/eslint-adapter.js
@@ -1,10 +1,10 @@
 var CLIEngine = require( 'eslint' ).CLIEngine,
-  cli = new CLIEngine( {
+  cli = new CLIEngine({
     useEslintrc: false,
     configFile: 'core.js',
     envs: [ 'es6' ],
     ignore: false
-  } );
+  });
 
 exports.executeOnText = function executeOnText( text ) {
   return cli.executeOnText( text );

--- a/test/support/eslint-assert.js
+++ b/test/support/eslint-assert.js
@@ -19,7 +19,7 @@ function iterableEqual( a, b ) {
   }
 
   for ( ; i < a.length; i++ ) {
-    if ( a[ i ] !== b[ i ] ) {
+    if ( a[ i ] !== b[ i ]) {
       match = false;
       break;
     }
@@ -44,7 +44,7 @@ Assertion.addMethod( 'eslintErrors', function assertEslintErrors( expectedRules 
   messages = eslint.formatReportResults( report.results );
   resultRules = results.messages.map( function extractRuleId( m ) {
     return m.ruleId;
-  } );
+  });
 
   this.assert(
     report.errorCount > 0 && Array.isArray( results.messages ) &&
@@ -55,4 +55,4 @@ Assertion.addMethod( 'eslintErrors', function assertEslintErrors( expectedRules 
     resultRules,
     true
   );
-} );
+});


### PR DESCRIPTION
Enable `space-in-parens` exceptions for `[]`, `{}`, `()`.

Enables code such as:
```js
foo([ 1, 2, 3 ]);
foo({ one: 1 });
```

Still not quite "idiomatic" for the following code, which will error:
```js
// no space for single named function param
foo(function foo() {

});

// consistent start and end
foo( something, [] );
foo( something, [ 1, 2, 3 ] );
```

Working on a plugin to fix the above.