### PR TITLE
Remove extends eslint:recommended

### DIFF
--- a/.eslintrc-es5.json
+++ b/.eslintrc-es5.json
@@ -1,6 +1,6 @@
 {
   "root": true,
-  "extends": "./core+recommended.js",
+  "extends": "./core.js",
   "parserOptions": {
     "ecmaVersion": 5
   },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,10 +1,7 @@
 {
   "root": true,
-  "extends": "./core+recommended.js",
+  "extends": "./core.js",
   "parserOptions": {
     "ecmaVersion": 6
-  },
-  "rules": {
-
   }
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ In your `.eslintrc` file:
 }
 ```
 
+To use with ESLint's recommended ruleset:
+```json
+{
+  "extends": [ "eslint:recommended", "idiomatic" ]
+}
+```
+
 ### Overrides
 You can easily override rules in your own `.eslintrc` config. For example, to
 use 4 space indents instead of 2:

--- a/README.md
+++ b/README.md
@@ -11,10 +11,13 @@ Ensure your source code adheres to the [idiomatic js] coding style by linting
 your code with [ESLint]. Hook ESLint into your editor and build pipeline for
 maximum effect.
 
+> :memo: ** Note for upgrades from v2.x:** this config no longer extends `eslint:recommended`. See [Usage](#usage).
+
 **Idiomatic example:**
 ```js
 const thing = 'Hello',
-  another = 'World';
+  another = 'World',
+  total = count([ 1, 2, 3]);
 
 function idiomatic( arg ) {
   let out = 'Bye';
@@ -27,10 +30,6 @@ function idiomatic( arg ) {
 }
 ```
 
-`eslint-config-idiomatic` also includes extra recommended linting rules to
-prevent potential issues in your code. This is so that it may be dropped into
-any project with minimal extra configuration necessary.
-
 ## Install
 ```
 npm install --save-dev eslint-config-idiomatic
@@ -38,6 +37,7 @@ npm install --save-dev eslint-config-idiomatic
 
 Note:
 
+ * use version `^3.0.0` for ESLint version `^3.x.x`.
  * use version `^2.0.0` for ESLint version `^2.x.x`.
  * use version `^1.0.0` for ESLint version `^1.x.x`.
 
@@ -53,9 +53,14 @@ In your `.eslintrc` file:
 To use with ESLint's recommended ruleset:
 ```json
 {
-  "extends": [ "eslint:recommended", "idiomatic" ]
+  "extends": [
+    "eslint:recommended",
+    "idiomatic"
+  ]
 }
 ```
+
+Note: `eslint:recommended` should be listed first.
 
 ### Overrides
 You can easily override rules in your own `.eslintrc` config. For example, to
@@ -78,18 +83,6 @@ in your `.eslintrc`:
 }
 ```
 
-### Idiomatic style only
-`eslint-config-idiomatic` includes recommended [ESLint rules] to avoid other
-potential issues in your code. To restrict to idiomatic code style only, extend
-`idiomatic/core` in your `.eslintrc`:
-```json
-{
-  "extends": "idiomatic/core",
-  "rules": {
-    "...": "my additional linting rules"
-  }
-}
-```
 
 ## Slight differences
 The rules enforces by this config may differ slightly from the idiomatic js

--- a/core+recommended.js
+++ b/core+recommended.js
@@ -1,7 +1,0 @@
-/*eslint-env node */
-
-var loadConfig = require( './lib/loader' ).loadConfig;
-
-module.exports = loadConfig( '.eslintrc-core.json' );
-
-module.exports[ 'extends' ] = 'eslint:recommended';

--- a/es5.js
+++ b/es5.js
@@ -4,4 +4,4 @@ var loadConfig = require( './lib/loader' ).loadConfig;
 
 module.exports = loadConfig( '.eslintrc-es5.json' );
 
-module.exports[ 'extends' ] = 'idiomatic/core+recommended';
+module.exports[ 'extends' ] = 'idiomatic/core';

--- a/index.js
+++ b/index.js
@@ -4,4 +4,4 @@ var loadConfig = require( './lib/loader' ).loadConfig;
 
 module.exports = loadConfig( '.eslintrc.json' );
 
-module.exports[ 'extends' ] = 'idiomatic/core+recommended';
+module.exports[ 'extends' ] = 'idiomatic/core';


### PR DESCRIPTION
Removes automatic extends of `eslint:recommended` from the config in favour of clients using:

```yaml
---
  extends:
  - eslint:recommended
  - idiomatic
```

In the future, this config will include rules from `eslint:recommended` that idiomatic recommends as well. This change is to ensure that the config remains immutable, as `eslint:recommended` is a moving target which can vary between eslint releases.